### PR TITLE
feat: networked packet compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,6 +250,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
+name = "cmake"
+version = "0.1.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb1e43aa7fd152b1f968787f7dbcdeb306d1867ff373c69955211876c053f91a"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "color-eyre"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -311,6 +320,7 @@ dependencies = [
  "color-eyre",
  "fastanvil",
  "fastnbt",
+ "flate2",
  "rand",
  "rayon",
  "serde",
@@ -444,11 +454,12 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.34"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0"
+checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
 dependencies = [
  "crc32fast",
+ "libz-ng-sys",
  "miniz_oxide 0.8.0",
 ]
 
@@ -581,6 +592,16 @@ dependencies = [
  "bitflags",
  "libc",
  "redox_syscall",
+]
+
+[[package]]
+name = "libz-ng-sys"
+version = "1.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f0f7295a34685977acb2e8cc8b08ee4a8dffd6cf278eeccddbe1ed55ba815d5"
+dependencies = [
+ "cmake",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ clap = { version = "4.5.20", features = ["derive", "env"] }
 color-eyre = "0.6.3"
 fastanvil = { git = "https://github.com/owengage/fastnbt.git" }
 fastnbt = { git = "https://github.com/owengage/fastnbt.git" }
+flate2 = { version = "1.0.35", default-features = false, features = ["zlib-ng"] }
 rand = "0.8.5"
 rayon = "1.10.0"
 serde = { version = "1.0.213", features = ["derive"] }

--- a/flake.nix
+++ b/flake.nix
@@ -80,7 +80,7 @@
               cargoLock.outputHashes."fastnbt-2.5.0" = "E4WI6SZgkjqUOtbfXfKGfpFH7btEh5V0KpMXSIsuh08=";
               inherit buildType;
               dontStrip = buildType == "debug";
-              buildInputs = with pkgs; [pkg-config openssl];
+              buildInputs = with pkgs; [pkg-config openssl cmake];
             };
         in {
           default = mkCrawlspace "debug";

--- a/src/net/io.rs
+++ b/src/net/io.rs
@@ -30,7 +30,7 @@ use tokio::{
     sync::{Mutex, RwLock},
 };
 
-use crate::protocol::{self, ClientboundPacket, Frame, ServerboundPacket};
+use crate::protocol::{self, datatypes::VarInt, ClientboundPacket, Frame, ServerboundPacket};
 
 #[derive(Debug)]
 pub struct NetIo {


### PR DESCRIPTION
Implements network compression in accordance with https://minecraft.wiki/w/Minecraft_Wiki:Projects/wiki.vg_merge/Protocol#With_compression. This will remain behind a feature flag, but will probably be enabled by default as it's not required but will greatly reduce bandwidth usage (and will probably make our proxies slightly happier).